### PR TITLE
Add name rotation spinbot + toggle commands

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1347,6 +1347,21 @@ void CGameContext::CmdStats(CGameContext* pContext, int pClientID, const char** 
 {
 }
 
+void CGameContext::CmdSpinbot(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum)
+{
+	bool state = true;
+	if (ArgNum > 0) {
+		if (strcmp(pArgs[0], "off") == 0) {
+			state = false;
+			pContext->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "spinbotarg", pArgs[0]);
+		}
+	}
+	
+	CPlayer* p = pContext->m_apPlayers[pClientID];
+	p->m_spinbot = state;
+	
+}
+
 void CGameContext::CmdWhisper(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum){
 	CPlayer* p = pContext->m_apPlayers[pClientID];
 	
@@ -2059,6 +2074,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 	AddServerCommand("c", "whisper to the player, you whispered to last", "<text>", CmdConversation);
 	AddServerCommand("help", "show the cmd list or get more information to any command", "<command>", CmdHelp);
 	AddServerCommand("cmdlist", "show the cmd list", 0, CmdHelp);
+	AddServerCommand("spinbot", "enable spin bot", 0, CmdSpinbot);
 	if(m_Config->m_SvEmoteWheel || m_Config->m_SvEmotionalTees) AddServerCommand("emote", "enable custom emotes", "<emote type> <time in seconds>", CmdEmote);
 
 	//if(!data) // only load once

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -179,6 +179,7 @@ public:
 	void ExecuteServerCommand(int pClientID, const char* pLine);
 	
 	static void CmdStats(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum);
+	static void CmdSpinbot(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum);
 	static void CmdWhisper(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum);
 	static void CmdConversation(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum);
 	static void CmdHelp(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -43,6 +43,7 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, int Team)
 	m_selfkills = 0;
 	m_teamkills = 0;
 	m_unfreeze = 0;
+	m_spinbot = false;
 
 	m_ChatSpamCount = 0;
 	
@@ -99,6 +100,19 @@ void CPlayer::Tick()
 		// each second
 		if(Server()->Tick()%Server()->TickSpeed() == 0)
 		{
+			if (m_spinbot) {
+				char player_name[256];
+				str_copy(player_name, Server()->ClientName(m_ClientID), sizeof(player_name));
+				int l = strlen(player_name);
+				char c = player_name[0];
+				for (int i=0; i<l; i++) {
+					player_name[i] = player_name[i+1];
+				}
+				player_name[l-1] = c;
+			
+				Server()->SetClientName(m_ClientID, player_name);
+			}
+			
 			m_Latency.m_Avg = m_Latency.m_Accum/Server()->TickSpeed();
 			m_Latency.m_Max = m_Latency.m_AccumMax;
 			m_Latency.m_Min = m_Latency.m_AccumMin;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -64,6 +64,7 @@ public:
 	int m_selfkills;
 	int m_teamkills;
 	int m_unfreeze;
+	bool m_spinbot; // If the player is spinning automatically
 
 	//client version
 	char m_ClientVersion;


### PR DESCRIPTION
WIP. Known issues:
- Doesn't rotate unicode names correctly (rotates bytes)
- Keeps chatting about rotation name changes after player has changes his name from the client too.
- Other players can 'hijack' a name when a player starts rotating it.